### PR TITLE
Deps: Use w3c-xmlhttprequest instead of xmlhttprequest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,22 @@
 {
-  "name": "pokeclicker-desktop",
+  "name": "pokeclicker-desktop-with-scripts",
   "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "pokeclicker-desktop",
+      "name": "pokeclicker-desktop-with-scripts",
       "version": "1.1.0",
       "license": "ISC",
       "dependencies": {
         "adm-zip": "^0.5.9",
         "discord-rpc": "^4.0.1",
-        "electron-updater": "^5.0.5",
-        "xmlhttprequest": "^1.8.0"
+        "electron-updater": "^5.2.1",
+        "w3c-xmlhttprequest": "^3.0.4"
       },
       "devDependencies": {
         "electron": "^19.0.10",
-        "electron-builder": "^23.1.0"
+        "electron-builder": "^23.3.3"
       }
     },
     "node_modules/@develar/schema-utils": {
@@ -392,9 +392,9 @@
       "dev": true
     },
     "node_modules/app-builder-lib": {
-      "version": "23.1.0",
-      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-23.1.0.tgz",
-      "integrity": "sha512-aZpKjBBLzyxtr4Cmbyi3dl8uRO8SI2PG2MYEKYRZL6pl7IsKP2hJkCYzlD6NjLJlRIAZcFPFjFbJliO74DFf7w==",
+      "version": "23.3.3",
+      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-23.3.3.tgz",
+      "integrity": "sha512-m0+M53+HYMzqKxwNQZT143K7WwXEGUy9LY31l8dJphXx2P/FQod615mVbxHyqbDCG4J5bHdWm21qZ0e2DVY6CQ==",
       "dev": true,
       "dependencies": {
         "@develar/schema-utils": "~2.6.5",
@@ -403,13 +403,13 @@
         "7zip-bin": "~5.1.1",
         "async-exit-hook": "^2.0.1",
         "bluebird-lst": "^1.0.9",
-        "builder-util": "23.0.9",
-        "builder-util-runtime": "9.0.2",
+        "builder-util": "23.3.3",
+        "builder-util-runtime": "9.0.3",
         "chromium-pickle-js": "^0.2.0",
         "debug": "^4.3.4",
         "ejs": "^3.1.7",
         "electron-osx-sign": "^0.6.0",
-        "electron-publish": "23.0.9",
+        "electron-publish": "23.3.3",
         "form-data": "^4.0.0",
         "fs-extra": "^10.1.0",
         "hosted-git-info": "^4.1.0",
@@ -727,9 +727,9 @@
       "dev": true
     },
     "node_modules/builder-util": {
-      "version": "23.0.9",
-      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-23.0.9.tgz",
-      "integrity": "sha512-ccPFwI1Sex4yLt8R3LI+H07p2jHICKwEWtxkFkb6jiU/g/VJnF1wazW7I1oMcCFcPTEl30GhqoRv9rfDD9VAiQ==",
+      "version": "23.3.3",
+      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-23.3.3.tgz",
+      "integrity": "sha512-MJZlUiq2PY5hjYv9+XNaoYdsITqvLgRDoHSFg/4nzpInbNxNjLQOolL04Zsyp+hgfcbFvMC4h0KkR1CMPHLWbA==",
       "dev": true,
       "dependencies": {
         "@types/debug": "^4.1.6",
@@ -737,7 +737,7 @@
         "7zip-bin": "~5.1.1",
         "app-builder-bin": "4.0.0",
         "bluebird-lst": "^1.0.9",
-        "builder-util-runtime": "9.0.2",
+        "builder-util-runtime": "9.0.3",
         "chalk": "^4.1.1",
         "cross-spawn": "^7.0.3",
         "debug": "^4.3.4",
@@ -752,9 +752,9 @@
       }
     },
     "node_modules/builder-util-runtime": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.0.2.tgz",
-      "integrity": "sha512-xF55W/8mgfT6+sMbX0TeiJkTusA5GMOzckM4rajN4KirFcUIuLTH8oEaTYmM86YwVCZaTwa/7GyFhauXaEICwA==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.0.3.tgz",
+      "integrity": "sha512-SfG2wnyjpUbbdtpnqDpWwklujofC6GarGpvdWrEkg9p5AD/xJmTF2buTNaqs3qtsNBEVQDDjZz9xc2GGpVyMfA==",
       "dependencies": {
         "debug": "^4.3.4",
         "sax": "^1.2.4"
@@ -1211,14 +1211,14 @@
       }
     },
     "node_modules/dmg-builder": {
-      "version": "23.1.0",
-      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-23.1.0.tgz",
-      "integrity": "sha512-CzhPk/k12nJ2KqTbePkIwHOLiaWneQu2cgXCT9Hb5FhwI1vxTPalLsg8OZ57wKCrkL8AEftqqSff8gB5yWY/xw==",
+      "version": "23.3.3",
+      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-23.3.3.tgz",
+      "integrity": "sha512-ECwAjt+ZWyOvddrkDx1xRD6IVUCZb5SV6vSMHZd+Va3G2sUXHrnglR1cGDKRF4oYRQm8SYVrpLZKbi8npyDcAQ==",
       "dev": true,
       "dependencies": {
-        "app-builder-lib": "23.1.0",
-        "builder-util": "23.0.9",
-        "builder-util-runtime": "9.0.2",
+        "app-builder-lib": "23.3.3",
+        "builder-util": "23.3.3",
+        "builder-util-runtime": "9.0.3",
         "fs-extra": "^10.0.0",
         "iconv-lite": "^0.6.2",
         "js-yaml": "^4.1.0"
@@ -1355,17 +1355,17 @@
       }
     },
     "node_modules/electron-builder": {
-      "version": "23.1.0",
-      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-23.1.0.tgz",
-      "integrity": "sha512-UEblaQY8N9m8/HriOwl7jgFJ4olpWDXwdDBqwUkQiRHVNRnCfrA0u8LV03li5ZYhma6zFWzfIZbHd+uk8y//lQ==",
+      "version": "23.3.3",
+      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-23.3.3.tgz",
+      "integrity": "sha512-mFYYdhoFPKevP6y5uaaF3dusmB2OtQ/HnwwpyOePeU7QDS0SEIAUokQsHUanAiJAZcBqtY7iyLBgX18QybdFFw==",
       "dev": true,
       "dependencies": {
         "@types/yargs": "^17.0.1",
-        "app-builder-lib": "23.1.0",
-        "builder-util": "23.0.9",
-        "builder-util-runtime": "9.0.2",
+        "app-builder-lib": "23.3.3",
+        "builder-util": "23.3.3",
+        "builder-util-runtime": "9.0.3",
         "chalk": "^4.1.1",
-        "dmg-builder": "23.1.0",
+        "dmg-builder": "23.3.3",
         "fs-extra": "^10.0.0",
         "is-ci": "^3.0.0",
         "lazy-val": "^1.0.5",
@@ -1465,14 +1465,14 @@
       "dev": true
     },
     "node_modules/electron-publish": {
-      "version": "23.0.9",
-      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-23.0.9.tgz",
-      "integrity": "sha512-afr2z6L07/elgDX+6I/G/0vzXOP6xYUd/aXx9tnTPSVZ/3AuvCegHrKiuh8sKYHmzoAcNGXe3ikISYIu961IfA==",
+      "version": "23.3.3",
+      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-23.3.3.tgz",
+      "integrity": "sha512-1dX17eE5xVXedTxjC+gjsP74oC0+sIHgqysp0ryTlF9+yfQUyXjBk6kcK+zhtBA2SsHMSglDtM+JPxDD/WpPTQ==",
       "dev": true,
       "dependencies": {
         "@types/fs-extra": "^9.0.11",
-        "builder-util": "23.0.9",
-        "builder-util-runtime": "9.0.2",
+        "builder-util": "23.3.3",
+        "builder-util-runtime": "9.0.3",
         "chalk": "^4.1.1",
         "fs-extra": "^10.0.0",
         "lazy-val": "^1.0.5",
@@ -1515,12 +1515,12 @@
       }
     },
     "node_modules/electron-updater": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-5.0.5.tgz",
-      "integrity": "sha512-YcKEI9zpU+c0sNXTpjw3UpzP8Pfuuwo70T42oLYm0hHc0dy41ih51oENlhxgooa2+uzzpXhoCOyrpG+w6CB0Pw==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-5.2.1.tgz",
+      "integrity": "sha512-OQZVIvqcK8j03HjT07uVPgvguP/r8RY2wZcwCM26+fcDOjtrm01Dfz3G8Eru+69znbrR+F9pDzr98ewMavBrWQ==",
       "dependencies": {
         "@types/semver": "^7.3.6",
-        "builder-util-runtime": "9.0.2",
+        "builder-util-runtime": "9.0.3",
         "fs-extra": "^10.0.0",
         "js-yaml": "^4.1.0",
         "lazy-val": "^1.0.5",
@@ -3407,6 +3407,14 @@
       "dev": true,
       "optional": true
     },
+    "node_modules/w3c-xmlhttprequest": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/w3c-xmlhttprequest/-/w3c-xmlhttprequest-3.0.4.tgz",
+      "integrity": "sha512-GOR3PNrFVioJtxb+VR1kp80+UM89ga85akLRYVZX7fmaQTn/kkj9Q18MhNoGtvRJ2ez5i77EpQ0hNBB7+e/RBg==",
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -3519,14 +3527,6 @@
       "dev": true,
       "engines": {
         "node": ">=8.0"
-      }
-    },
-    "node_modules/xmlhttprequest": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
-      "integrity": "sha512-58Im/U0mlVBLM38NdZjHyhuMtCqa61469k2YP/AaPbvCoV9aQGUpbJBj1QRm2ytRiVQBD/fsw7L2bJGDVQswBA==",
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/y18n": {
@@ -3882,9 +3882,9 @@
       "dev": true
     },
     "app-builder-lib": {
-      "version": "23.1.0",
-      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-23.1.0.tgz",
-      "integrity": "sha512-aZpKjBBLzyxtr4Cmbyi3dl8uRO8SI2PG2MYEKYRZL6pl7IsKP2hJkCYzlD6NjLJlRIAZcFPFjFbJliO74DFf7w==",
+      "version": "23.3.3",
+      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-23.3.3.tgz",
+      "integrity": "sha512-m0+M53+HYMzqKxwNQZT143K7WwXEGUy9LY31l8dJphXx2P/FQod615mVbxHyqbDCG4J5bHdWm21qZ0e2DVY6CQ==",
       "dev": true,
       "requires": {
         "@develar/schema-utils": "~2.6.5",
@@ -3893,13 +3893,13 @@
         "7zip-bin": "~5.1.1",
         "async-exit-hook": "^2.0.1",
         "bluebird-lst": "^1.0.9",
-        "builder-util": "23.0.9",
-        "builder-util-runtime": "9.0.2",
+        "builder-util": "23.3.3",
+        "builder-util-runtime": "9.0.3",
         "chromium-pickle-js": "^0.2.0",
         "debug": "^4.3.4",
         "ejs": "^3.1.7",
         "electron-osx-sign": "^0.6.0",
-        "electron-publish": "23.0.9",
+        "electron-publish": "23.3.3",
         "form-data": "^4.0.0",
         "fs-extra": "^10.1.0",
         "hosted-git-info": "^4.1.0",
@@ -4138,9 +4138,9 @@
       "dev": true
     },
     "builder-util": {
-      "version": "23.0.9",
-      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-23.0.9.tgz",
-      "integrity": "sha512-ccPFwI1Sex4yLt8R3LI+H07p2jHICKwEWtxkFkb6jiU/g/VJnF1wazW7I1oMcCFcPTEl30GhqoRv9rfDD9VAiQ==",
+      "version": "23.3.3",
+      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-23.3.3.tgz",
+      "integrity": "sha512-MJZlUiq2PY5hjYv9+XNaoYdsITqvLgRDoHSFg/4nzpInbNxNjLQOolL04Zsyp+hgfcbFvMC4h0KkR1CMPHLWbA==",
       "dev": true,
       "requires": {
         "@types/debug": "^4.1.6",
@@ -4148,7 +4148,7 @@
         "7zip-bin": "~5.1.1",
         "app-builder-bin": "4.0.0",
         "bluebird-lst": "^1.0.9",
-        "builder-util-runtime": "9.0.2",
+        "builder-util-runtime": "9.0.3",
         "chalk": "^4.1.1",
         "cross-spawn": "^7.0.3",
         "debug": "^4.3.4",
@@ -4192,9 +4192,9 @@
       }
     },
     "builder-util-runtime": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.0.2.tgz",
-      "integrity": "sha512-xF55W/8mgfT6+sMbX0TeiJkTusA5GMOzckM4rajN4KirFcUIuLTH8oEaTYmM86YwVCZaTwa/7GyFhauXaEICwA==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.0.3.tgz",
+      "integrity": "sha512-SfG2wnyjpUbbdtpnqDpWwklujofC6GarGpvdWrEkg9p5AD/xJmTF2buTNaqs3qtsNBEVQDDjZz9xc2GGpVyMfA==",
       "requires": {
         "debug": "^4.3.4",
         "sax": "^1.2.4"
@@ -4517,14 +4517,14 @@
       }
     },
     "dmg-builder": {
-      "version": "23.1.0",
-      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-23.1.0.tgz",
-      "integrity": "sha512-CzhPk/k12nJ2KqTbePkIwHOLiaWneQu2cgXCT9Hb5FhwI1vxTPalLsg8OZ57wKCrkL8AEftqqSff8gB5yWY/xw==",
+      "version": "23.3.3",
+      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-23.3.3.tgz",
+      "integrity": "sha512-ECwAjt+ZWyOvddrkDx1xRD6IVUCZb5SV6vSMHZd+Va3G2sUXHrnglR1cGDKRF4oYRQm8SYVrpLZKbi8npyDcAQ==",
       "dev": true,
       "requires": {
-        "app-builder-lib": "23.1.0",
-        "builder-util": "23.0.9",
-        "builder-util-runtime": "9.0.2",
+        "app-builder-lib": "23.3.3",
+        "builder-util": "23.3.3",
+        "builder-util-runtime": "9.0.3",
         "dmg-license": "^1.0.11",
         "fs-extra": "^10.0.0",
         "iconv-lite": "^0.6.2",
@@ -4625,17 +4625,17 @@
       }
     },
     "electron-builder": {
-      "version": "23.1.0",
-      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-23.1.0.tgz",
-      "integrity": "sha512-UEblaQY8N9m8/HriOwl7jgFJ4olpWDXwdDBqwUkQiRHVNRnCfrA0u8LV03li5ZYhma6zFWzfIZbHd+uk8y//lQ==",
+      "version": "23.3.3",
+      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-23.3.3.tgz",
+      "integrity": "sha512-mFYYdhoFPKevP6y5uaaF3dusmB2OtQ/HnwwpyOePeU7QDS0SEIAUokQsHUanAiJAZcBqtY7iyLBgX18QybdFFw==",
       "dev": true,
       "requires": {
         "@types/yargs": "^17.0.1",
-        "app-builder-lib": "23.1.0",
-        "builder-util": "23.0.9",
-        "builder-util-runtime": "9.0.2",
+        "app-builder-lib": "23.3.3",
+        "builder-util": "23.3.3",
+        "builder-util-runtime": "9.0.3",
         "chalk": "^4.1.1",
-        "dmg-builder": "23.1.0",
+        "dmg-builder": "23.3.3",
         "fs-extra": "^10.0.0",
         "is-ci": "^3.0.0",
         "lazy-val": "^1.0.5",
@@ -4714,14 +4714,14 @@
       }
     },
     "electron-publish": {
-      "version": "23.0.9",
-      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-23.0.9.tgz",
-      "integrity": "sha512-afr2z6L07/elgDX+6I/G/0vzXOP6xYUd/aXx9tnTPSVZ/3AuvCegHrKiuh8sKYHmzoAcNGXe3ikISYIu961IfA==",
+      "version": "23.3.3",
+      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-23.3.3.tgz",
+      "integrity": "sha512-1dX17eE5xVXedTxjC+gjsP74oC0+sIHgqysp0ryTlF9+yfQUyXjBk6kcK+zhtBA2SsHMSglDtM+JPxDD/WpPTQ==",
       "dev": true,
       "requires": {
         "@types/fs-extra": "^9.0.11",
-        "builder-util": "23.0.9",
-        "builder-util-runtime": "9.0.2",
+        "builder-util": "23.3.3",
+        "builder-util-runtime": "9.0.3",
         "chalk": "^4.1.1",
         "fs-extra": "^10.0.0",
         "lazy-val": "^1.0.5",
@@ -4758,12 +4758,12 @@
       }
     },
     "electron-updater": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-5.0.5.tgz",
-      "integrity": "sha512-YcKEI9zpU+c0sNXTpjw3UpzP8Pfuuwo70T42oLYm0hHc0dy41ih51oENlhxgooa2+uzzpXhoCOyrpG+w6CB0Pw==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-5.2.1.tgz",
+      "integrity": "sha512-OQZVIvqcK8j03HjT07uVPgvguP/r8RY2wZcwCM26+fcDOjtrm01Dfz3G8Eru+69znbrR+F9pDzr98ewMavBrWQ==",
       "requires": {
         "@types/semver": "^7.3.6",
-        "builder-util-runtime": "9.0.2",
+        "builder-util-runtime": "9.0.3",
         "fs-extra": "^10.0.0",
         "js-yaml": "^4.1.0",
         "lazy-val": "^1.0.5",
@@ -6246,6 +6246,11 @@
         }
       }
     },
+    "w3c-xmlhttprequest": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/w3c-xmlhttprequest/-/w3c-xmlhttprequest-3.0.4.tgz",
+      "integrity": "sha512-GOR3PNrFVioJtxb+VR1kp80+UM89ga85akLRYVZX7fmaQTn/kkj9Q18MhNoGtvRJ2ez5i77EpQ0hNBB7+e/RBg=="
+    },
     "webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -6324,11 +6329,6 @@
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
       "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
       "dev": true
-    },
-    "xmlhttprequest": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
-      "integrity": "sha512-58Im/U0mlVBLM38NdZjHyhuMtCqa61469k2YP/AaPbvCoV9aQGUpbJBj1QRm2ytRiVQBD/fsw7L2bJGDVQswBA=="
     },
     "y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -22,12 +22,12 @@
   "dependencies": {
     "adm-zip": "^0.5.9",
     "discord-rpc": "^4.0.1",
-    "xmlhttprequest": "^1.8.0",
-    "electron-updater": "^5.0.5"
+    "w3c-xmlhttprequest": "^3.0.4",
+    "electron-updater": "^5.2.1"
   },
   "devDependencies": {
     "electron": "^19.0.10",
-    "electron-builder": "^23.1.0"
+    "electron-builder": "^23.3.3"
   },
   "build": {
     "productName": "PokéClicker with Scripts",

--- a/src/main.js
+++ b/src/main.js
@@ -9,7 +9,7 @@ const url = require('url');
 const DiscordRPC = require('discord-rpc');
 const https = require('https');
 const fs = require('fs');
-const XMLHttpRequest = require("xmlhttprequest").XMLHttpRequest;
+const XMLHttpRequest = require("w3c-xmlhttprequest").XMLHttpRequest;
 const Zip = require('adm-zip');
 const electron = require('electron');
 


### PR DESCRIPTION
The xmlhttprequest package is not updated since 2015.
Switch to the w3c-xmlhttprequest package for more up-to-date
support for XMLHttpRequest.