### PR TITLE
Use `Function` instead of `eval`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pokeclicker-desktop-with-scripts",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pokeclicker-desktop-with-scripts",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "PokeClicker with Scripts Desktop",
   "repository": {
     "type": "git",

--- a/src/AutomationScriptManager.js
+++ b/src/AutomationScriptManager.js
@@ -373,7 +373,7 @@ class AutomationScriptManager
 
             try
             {
-                eval(script.content);
+                Function(script.content)();
             }
             catch(error)
             {


### PR DESCRIPTION
The `eval` function is pretty slow and risky
(since it runs the code with the caller's privileges).

See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval

---

The `Function` class is still risky but mitigates the risk
by running the code on the global scope only.

In addition, the code evaluated is less strict about JS syntaxe.
Fixes #21 
Fixes #22 

See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function