### PR TITLE
Fixup CVE-2023-5217

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pokeclicker-desktop-with-scripts",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pokeclicker-desktop-with-scripts",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "license": "ISC",
       "dependencies": {
         "adm-zip": "^0.5.10",
@@ -1363,9 +1363,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "26.2.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-26.2.1.tgz",
-      "integrity": "sha512-SNT24Cf/wRvfcFZQoERXjzswUlg5ouqhIuA2t9x2L7VdTn+2Jbs0QXRtOfzcnOV/raVMz3e8ICyaU2GGeciKLg==",
+      "version": "26.3.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-26.3.0.tgz",
+      "integrity": "sha512-7ZpvSHu+jmqialSvywTZnOQZZGLqlyj+yV5HGDrEzFnMiFaXBRpbByHgoUhaExJ/8t/0xKQjKlMRAY65w+zNZQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -4199,9 +4199,9 @@
       }
     },
     "electron": {
-      "version": "26.2.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-26.2.1.tgz",
-      "integrity": "sha512-SNT24Cf/wRvfcFZQoERXjzswUlg5ouqhIuA2t9x2L7VdTn+2Jbs0QXRtOfzcnOV/raVMz3e8ICyaU2GGeciKLg==",
+      "version": "26.3.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-26.3.0.tgz",
+      "integrity": "sha512-7ZpvSHu+jmqialSvywTZnOQZZGLqlyj+yV5HGDrEzFnMiFaXBRpbByHgoUhaExJ/8t/0xKQjKlMRAY65w+zNZQ==",
       "dev": true,
       "requires": {
         "@electron/get": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pokeclicker-desktop-with-scripts",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "PokeClicker with Scripts Desktop",
   "repository": {
     "type": "git",
@@ -28,7 +28,7 @@
     "electron-updater": "^6.1.4"
   },
   "devDependencies": {
-    "electron": "^26.2.1",
+    "electron": "^26.3.0",
     "electron-builder": "^24.6.4"
   },
   "build": {


### PR DESCRIPTION
The electron app was impacted with this 8.8/10 CVE from v26.0.0 to v26.2.3 
Updating the following dependencies to fix that issue:
  - electron : 26.3.0