### PR TITLE
Add CLI arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,10 @@ A web wrapper for Pokeclicker with scripts support
 ## Features from the `With Scripts support` version:
 - Runs the [pokeclicker-automation](https://github.com/Farigh/pokeclicker-automation), which can be disabled
 - Allows to add more scripts to run (with toggles to enable/disable them individually)
+- CLI support
+```text
+Available arguments:
+  --help              Displays the help message
+  --disable-scripts   Disables the custom scripts execution
+                      This can be usefull if the scripts messes everything up
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pokeclicker-desktop-with-scripts",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pokeclicker-desktop-with-scripts",
-      "version": "1.2.5",
+      "version": "1.2.6",
       "license": "ISC",
       "dependencies": {
         "adm-zip": "^0.5.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pokeclicker-desktop-with-scripts",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "PokeClicker with Scripts Desktop",
   "repository": {
     "type": "git",

--- a/src/AutomationScriptManager.js
+++ b/src/AutomationScriptManager.js
@@ -1,8 +1,9 @@
 class AutomationScriptManager
 {
-    static run(automationBaseUrl)
+    static run(automationBaseUrl, areScriptEnabled)
     {
         this.__internal__automationBaseUrl = automationBaseUrl;
+        this.__internal__areScriptEnabled = areScriptEnabled;
 
         // Set the automation script settings default values
         this.__internal__setDefaultLocalStorageValue(this.__internal__defaultScriptEnabledKey, true);
@@ -365,6 +366,12 @@ class AutomationScriptManager
         let customScriptsErrorCount = 0;
         for (const script of this.__internal__customScriptList)
         {
+            if (!this.__internal__areScriptEnabled)
+            {
+                // Don't execute any script in this case
+                break;
+            }
+
             if (localStorage.getItem(script.storageKey) != "true")
             {
                 // Don't run disabled scripts
@@ -613,6 +620,15 @@ class AutomationScriptManager
         // Set the current state
         const isFeatureEnabled = (localStorage.getItem(id) === "true");
         buttonElem.setAttribute("checked", isFeatureEnabled ? "true" : "false");
+
+        // Disable custom scripts button if script execution is disabled
+        if (!this.__internal__areScriptEnabled
+            && (id != this.__internal__defaultScriptEnabledKey)
+            && (id != this.__internal__defaultScriptDisableFeatureKey)
+            && (id != this.__internal__defaultScriptDisableSettingsKey))
+        {
+            buttonElem.setAttribute("disabled", "true");
+        }
 
         // Register the onclick event callback
         buttonElem.onclick = function()


### PR DESCRIPTION
The following arguments are available:
```text
  --help              Displays the help message
  --disable-scripts   Disables the custom scripts execution
                      This can be usefull if the scripts messes
                      everything up
```

When the `--disable-scripts` option is passed, the window title will display `Pokéclicker with script (Custom script execution disabled)`

In addition, every custom script toogle will be disabled : 
![image](https://github.com/Farigh/pokeclicker-automation-desktop/assets/11090416/91ef20de-ecb3-440b-9e85-4dfda24a2f30)
