### PR TITLE
Fixup CVE-2024-37890

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,21 @@
 {
   "name": "pokeclicker-desktop-with-scripts",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pokeclicker-desktop-with-scripts",
-      "version": "1.2.7",
+      "version": "1.2.8",
       "license": "ISC",
       "dependencies": {
-        "adm-zip": "^0.5.10",
+        "adm-zip": "^0.5.14",
         "discord-rpc": "^4.0.1",
-        "electron-updater": "^6.1.8",
+        "electron-updater": "^6.2.1",
         "w3c-xmlhttprequest": "^3.0.4"
       },
       "devDependencies": {
-        "electron": "^29.1.0",
+        "electron": "^31.0.2",
         "electron-builder": "^24.13.3"
       }
     },
@@ -615,11 +615,11 @@
       "dev": true
     },
     "node_modules/adm-zip": {
-      "version": "0.5.10",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.10.tgz",
-      "integrity": "sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ==",
+      "version": "0.5.14",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.14.tgz",
+      "integrity": "sha512-DnyqqifT4Jrcvb8USYjp6FHtBpEIz1mnXu6pTRHZ0RL69LbQYiO+0lDFg5+OKA7U29oWSs3a/i8fhn8ZcceIWg==",
       "engines": {
-        "node": ">=6.0"
+        "node": ">=12.0"
       }
     },
     "node_modules/agent-base": {
@@ -1067,7 +1067,6 @@
       "version": "9.2.4",
       "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.2.4.tgz",
       "integrity": "sha512-upp+biKpN/XZMLim7aguUyW8s0FUpDvOtK6sbanMFDAMBzpHDqdhgVYm6zc9HJ6nWo7u2Lxk60i2M6Jd3aiNrA==",
-      "dev": true,
       "dependencies": {
         "debug": "^4.3.4",
         "sax": "^1.2.4"
@@ -1524,7 +1523,7 @@
       "integrity": "sha512-HOvHpbq5STRZJjQIBzwoKnQ0jHplbEWFWlPDwXXKm/bILh4nzjcg7mNqll0UY7RsjFoaXA7e/oYb/4lvpda2zA==",
       "dependencies": {
         "node-fetch": "^2.6.1",
-        "ws": "^7.3.1"
+        "ws": "^7.5.10"
       },
       "optionalDependencies": {
         "register-scheme": "github:devsnek/node-register-scheme"
@@ -1630,9 +1629,9 @@
       "dev": true
     },
     "node_modules/ejs": {
-      "version": "3.1.9",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.9.tgz",
-      "integrity": "sha512-rC+QVNMJWv+MtPgkt0y+0rVEIdbtxVADApW9JXrUVlzHetgcyczP/E7DJmWJ4fJCZF2cPcBk0laWO9ZHMG3DmQ==",
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
+      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
       "dev": true,
       "dependencies": {
         "jake": "^10.8.5"
@@ -1645,9 +1644,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "29.1.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-29.1.0.tgz",
-      "integrity": "sha512-giJVIm0sWVp+8V1GXrKqKTb+h7no0P3ooYqEd34AD9wMJzGnAeL+usj+R0155/0pdvvP1mgydnA7lcaFA2M9lw==",
+      "version": "31.0.2",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-31.0.2.tgz",
+      "integrity": "sha512-55efQ5yfLN+AQHcFC00AXQqtxC3iAGaxX2GQ3EDbFJ0ca9GHNOdSXkcrdBElLleiDrR2hpXNkQxN1bDn0oxe6w==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -1825,11 +1824,11 @@
       }
     },
     "node_modules/electron-updater": {
-      "version": "6.1.8",
-      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.1.8.tgz",
-      "integrity": "sha512-hhOTfaFAd6wRHAfUaBhnAOYc+ymSGCWJLtFkw4xJqOvtpHmIdNHnXDV9m1MHC+A6q08Abx4Ykgyz/R5DGKNAMQ==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.2.1.tgz",
+      "integrity": "sha512-83eKIPW14qwZqUUM6wdsIRwVKZyjmHxQ4/8G+1C6iS5PdDt7b1umYQyj1/qPpH510GmHEQe4q0kCPe3qmb3a0Q==",
       "dependencies": {
-        "builder-util-runtime": "9.2.3",
+        "builder-util-runtime": "9.2.4",
         "fs-extra": "^10.1.0",
         "js-yaml": "^4.1.0",
         "lazy-val": "^1.0.5",
@@ -1837,18 +1836,6 @@
         "lodash.isequal": "^4.5.0",
         "semver": "^7.3.8",
         "tiny-typed-emitter": "^2.1.0"
-      }
-    },
-    "node_modules/electron-updater/node_modules/builder-util-runtime": {
-      "version": "9.2.3",
-      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.2.3.tgz",
-      "integrity": "sha512-FGhkqXdFFZ5dNC4C+yuQB9ak311rpGAw+/ASz8ZdxwODCv1GGMWgLDeofRkdi0F3VCHQEWy/aXcJQozx2nOPiw==",
-      "dependencies": {
-        "debug": "^4.3.4",
-        "sax": "^1.2.4"
-      },
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "node_modules/electron-updater/node_modules/fs-extra": {
@@ -3443,9 +3430,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.0.tgz",
-      "integrity": "sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
       "dev": true,
       "dependencies": {
         "chownr": "^2.0.0",
@@ -3715,9 +3702,9 @@
       "dev": true
     },
     "node_modules/ws": {
-      "version": "7.5.8",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.8.tgz",
-      "integrity": "sha512-ri1Id1WinAX5Jqn9HejiGb8crfRio0Qgu8+MtL36rlTA6RLsMdWt1Az/19A2Qij6uSHUMphEFaTKa4WG+UNHNw==",
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "engines": {
         "node": ">=8.3.0"
       },
@@ -4299,9 +4286,9 @@
       "dev": true
     },
     "adm-zip": {
-      "version": "0.5.10",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.10.tgz",
-      "integrity": "sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ=="
+      "version": "0.5.14",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.14.tgz",
+      "integrity": "sha512-DnyqqifT4Jrcvb8USYjp6FHtBpEIz1mnXu6pTRHZ0RL69LbQYiO+0lDFg5+OKA7U29oWSs3a/i8fhn8ZcceIWg=="
     },
     "agent-base": {
       "version": "6.0.2",
@@ -4687,7 +4674,6 @@
       "version": "9.2.4",
       "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.2.4.tgz",
       "integrity": "sha512-upp+biKpN/XZMLim7aguUyW8s0FUpDvOtK6sbanMFDAMBzpHDqdhgVYm6zc9HJ6nWo7u2Lxk60i2M6Jd3aiNrA==",
-      "dev": true,
       "requires": {
         "debug": "^4.3.4",
         "sax": "^1.2.4"
@@ -5000,7 +4986,7 @@
       "requires": {
         "node-fetch": "^2.6.1",
         "register-scheme": "github:devsnek/node-register-scheme",
-        "ws": "^7.3.1"
+        "ws": "^7.5.10"
       }
     },
     "dmg-builder": {
@@ -5083,18 +5069,18 @@
       "dev": true
     },
     "ejs": {
-      "version": "3.1.9",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.9.tgz",
-      "integrity": "sha512-rC+QVNMJWv+MtPgkt0y+0rVEIdbtxVADApW9JXrUVlzHetgcyczP/E7DJmWJ4fJCZF2cPcBk0laWO9ZHMG3DmQ==",
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
+      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
       "dev": true,
       "requires": {
         "jake": "^10.8.5"
       }
     },
     "electron": {
-      "version": "29.1.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-29.1.0.tgz",
-      "integrity": "sha512-giJVIm0sWVp+8V1GXrKqKTb+h7no0P3ooYqEd34AD9wMJzGnAeL+usj+R0155/0pdvvP1mgydnA7lcaFA2M9lw==",
+      "version": "31.0.2",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-31.0.2.tgz",
+      "integrity": "sha512-55efQ5yfLN+AQHcFC00AXQqtxC3iAGaxX2GQ3EDbFJ0ca9GHNOdSXkcrdBElLleiDrR2hpXNkQxN1bDn0oxe6w==",
       "dev": true,
       "requires": {
         "@electron/get": "^2.0.0",
@@ -5240,11 +5226,11 @@
       }
     },
     "electron-updater": {
-      "version": "6.1.8",
-      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.1.8.tgz",
-      "integrity": "sha512-hhOTfaFAd6wRHAfUaBhnAOYc+ymSGCWJLtFkw4xJqOvtpHmIdNHnXDV9m1MHC+A6q08Abx4Ykgyz/R5DGKNAMQ==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.2.1.tgz",
+      "integrity": "sha512-83eKIPW14qwZqUUM6wdsIRwVKZyjmHxQ4/8G+1C6iS5PdDt7b1umYQyj1/qPpH510GmHEQe4q0kCPe3qmb3a0Q==",
       "requires": {
-        "builder-util-runtime": "9.2.3",
+        "builder-util-runtime": "9.2.4",
         "fs-extra": "^10.1.0",
         "js-yaml": "^4.1.0",
         "lazy-val": "^1.0.5",
@@ -5254,15 +5240,6 @@
         "tiny-typed-emitter": "^2.1.0"
       },
       "dependencies": {
-        "builder-util-runtime": {
-          "version": "9.2.3",
-          "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.2.3.tgz",
-          "integrity": "sha512-FGhkqXdFFZ5dNC4C+yuQB9ak311rpGAw+/ASz8ZdxwODCv1GGMWgLDeofRkdi0F3VCHQEWy/aXcJQozx2nOPiw==",
-          "requires": {
-            "debug": "^4.3.4",
-            "sax": "^1.2.4"
-          }
-        },
         "fs-extra": {
           "version": "10.1.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
@@ -6484,9 +6461,9 @@
       }
     },
     "tar": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.0.tgz",
-      "integrity": "sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
       "dev": true,
       "requires": {
         "chownr": "^2.0.0",
@@ -6700,9 +6677,9 @@
       "dev": true
     },
     "ws": {
-      "version": "7.5.8",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.8.tgz",
-      "integrity": "sha512-ri1Id1WinAX5Jqn9HejiGb8crfRio0Qgu8+MtL36rlTA6RLsMdWt1Az/19A2Qij6uSHUMphEFaTKa4WG+UNHNw==",
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "requires": {}
     },
     "xmlbuilder": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pokeclicker-desktop-with-scripts",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "PokeClicker with Scripts Desktop",
   "repository": {
     "type": "git",
@@ -22,13 +22,13 @@
   },
   "license": "ISC",
   "dependencies": {
-    "adm-zip": "^0.5.10",
+    "adm-zip": "^0.5.14",
     "discord-rpc": "^4.0.1",
     "w3c-xmlhttprequest": "^3.0.4",
-    "electron-updater": "^6.1.8"
+    "electron-updater": "^6.2.1"
   },
   "devDependencies": {
-    "electron": "^29.1.0",
+    "electron": "^31.0.2",
     "electron-builder": "^24.13.3"
   },
   "build": {


### PR DESCRIPTION
The ws node package was impacted with this 7.5/10 CVE until v7.5.10

Updating the following dependencies to fix that issue:
  - ws: 7.5.10

The following dependencies were updated as well:
  - adm-zip: 0.5.14
  - electron: 31.0.2
  - electron-updater: 6.2.1