### PR TITLE
Fixup CVE-2024-39698

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,21 @@
 {
   "name": "pokeclicker-desktop-with-scripts",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pokeclicker-desktop-with-scripts",
-      "version": "1.2.8",
+      "version": "1.2.9",
       "license": "ISC",
       "dependencies": {
         "adm-zip": "^0.5.14",
         "discord-rpc": "^4.0.1",
-        "electron-updater": "^6.2.1",
+        "electron-updater": "^6.3.0",
         "w3c-xmlhttprequest": "^3.0.4"
       },
       "devDependencies": {
-        "electron": "^31.0.2",
+        "electron": "^31.2.1",
         "electron-builder": "^24.13.3"
       }
     },
@@ -1067,6 +1067,7 @@
       "version": "9.2.4",
       "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.2.4.tgz",
       "integrity": "sha512-upp+biKpN/XZMLim7aguUyW8s0FUpDvOtK6sbanMFDAMBzpHDqdhgVYm6zc9HJ6nWo7u2Lxk60i2M6Jd3aiNrA==",
+      "dev": true,
       "dependencies": {
         "debug": "^4.3.4",
         "sax": "^1.2.4"
@@ -1644,9 +1645,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "31.0.2",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-31.0.2.tgz",
-      "integrity": "sha512-55efQ5yfLN+AQHcFC00AXQqtxC3iAGaxX2GQ3EDbFJ0ca9GHNOdSXkcrdBElLleiDrR2hpXNkQxN1bDn0oxe6w==",
+      "version": "31.2.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-31.2.1.tgz",
+      "integrity": "sha512-g3CLKjl4yuXt6VWm/KpgEjYYhFiCl19RgUn8lOC8zV/56ZXAS3+mqV4wWzicE/7vSYXs6GRO7vkYRwrwhX3Gaw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -1824,11 +1825,11 @@
       }
     },
     "node_modules/electron-updater": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.2.1.tgz",
-      "integrity": "sha512-83eKIPW14qwZqUUM6wdsIRwVKZyjmHxQ4/8G+1C6iS5PdDt7b1umYQyj1/qPpH510GmHEQe4q0kCPe3qmb3a0Q==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.3.0.tgz",
+      "integrity": "sha512-3Xlezhk+dKaSQrOnkQNqCGiuGSSUPO9BV9TQZ4Iig6AyTJ4FzJONE5gFFc382sY53Sh9dwJfzKsA3DxRHt2btw==",
       "dependencies": {
-        "builder-util-runtime": "9.2.4",
+        "builder-util-runtime": "9.2.5",
         "fs-extra": "^10.1.0",
         "js-yaml": "^4.1.0",
         "lazy-val": "^1.0.5",
@@ -1836,6 +1837,18 @@
         "lodash.isequal": "^4.5.0",
         "semver": "^7.3.8",
         "tiny-typed-emitter": "^2.1.0"
+      }
+    },
+    "node_modules/electron-updater/node_modules/builder-util-runtime": {
+      "version": "9.2.5",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.2.5.tgz",
+      "integrity": "sha512-HjIDfhvqx/8B3TDN4GbABQcgpewTU4LMRTQPkVpKYV3lsuxEJoIfvg09GyWTNmfVNSUAYf+fbTN//JX4TH20pg==",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "sax": "^1.2.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/electron-updater/node_modules/fs-extra": {
@@ -4674,6 +4687,7 @@
       "version": "9.2.4",
       "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.2.4.tgz",
       "integrity": "sha512-upp+biKpN/XZMLim7aguUyW8s0FUpDvOtK6sbanMFDAMBzpHDqdhgVYm6zc9HJ6nWo7u2Lxk60i2M6Jd3aiNrA==",
+      "dev": true,
       "requires": {
         "debug": "^4.3.4",
         "sax": "^1.2.4"
@@ -5078,9 +5092,9 @@
       }
     },
     "electron": {
-      "version": "31.0.2",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-31.0.2.tgz",
-      "integrity": "sha512-55efQ5yfLN+AQHcFC00AXQqtxC3iAGaxX2GQ3EDbFJ0ca9GHNOdSXkcrdBElLleiDrR2hpXNkQxN1bDn0oxe6w==",
+      "version": "31.2.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-31.2.1.tgz",
+      "integrity": "sha512-g3CLKjl4yuXt6VWm/KpgEjYYhFiCl19RgUn8lOC8zV/56ZXAS3+mqV4wWzicE/7vSYXs6GRO7vkYRwrwhX3Gaw==",
       "dev": true,
       "requires": {
         "@electron/get": "^2.0.0",
@@ -5226,11 +5240,11 @@
       }
     },
     "electron-updater": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.2.1.tgz",
-      "integrity": "sha512-83eKIPW14qwZqUUM6wdsIRwVKZyjmHxQ4/8G+1C6iS5PdDt7b1umYQyj1/qPpH510GmHEQe4q0kCPe3qmb3a0Q==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.3.0.tgz",
+      "integrity": "sha512-3Xlezhk+dKaSQrOnkQNqCGiuGSSUPO9BV9TQZ4Iig6AyTJ4FzJONE5gFFc382sY53Sh9dwJfzKsA3DxRHt2btw==",
       "requires": {
-        "builder-util-runtime": "9.2.4",
+        "builder-util-runtime": "9.2.5",
         "fs-extra": "^10.1.0",
         "js-yaml": "^4.1.0",
         "lazy-val": "^1.0.5",
@@ -5240,6 +5254,15 @@
         "tiny-typed-emitter": "^2.1.0"
       },
       "dependencies": {
+        "builder-util-runtime": {
+          "version": "9.2.5",
+          "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.2.5.tgz",
+          "integrity": "sha512-HjIDfhvqx/8B3TDN4GbABQcgpewTU4LMRTQPkVpKYV3lsuxEJoIfvg09GyWTNmfVNSUAYf+fbTN//JX4TH20pg==",
+          "requires": {
+            "debug": "^4.3.4",
+            "sax": "^1.2.4"
+          }
+        },
         "fs-extra": {
           "version": "10.1.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pokeclicker-desktop-with-scripts",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "description": "PokeClicker with Scripts Desktop",
   "repository": {
     "type": "git",
@@ -25,10 +25,10 @@
     "adm-zip": "^0.5.14",
     "discord-rpc": "^4.0.1",
     "w3c-xmlhttprequest": "^3.0.4",
-    "electron-updater": "^6.2.1"
+    "electron-updater": "^6.3.0"
   },
   "devDependencies": {
-    "electron": "^31.0.2",
+    "electron": "^31.2.1",
     "electron-builder": "^24.13.3"
   },
   "build": {


### PR DESCRIPTION
The electron-updater app was impacted with this  7.5/10 CVE until v6.3.0
Updating the following dependencies to fix that issue:
  - electron: 31.2.1
  - electron-updater: 6.3.0